### PR TITLE
ETags in listing ops should include quotes around

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -1682,7 +1682,7 @@ def test_bucket_list_return_data():
     for obj in objs_list:
         key_name = obj['Key']
         key_data = data[key_name]
-        eq(obj['ETag'],key_data['ETag'].replace('"',''))
+        eq(obj['ETag'],key_data['ETag'])
         eq(obj['Size'],key_data['ContentLength'])
         eq(obj['Owner']['DisplayName'],key_data['DisplayName'])
         eq(obj['Owner']['ID'],key_data['ID'])
@@ -1726,7 +1726,7 @@ def test_bucket_list_return_data_versioning():
         key_name = obj['Key']
         key_data = data[key_name]
         eq(obj['Owner']['DisplayName'],key_data['DisplayName'])
-        eq(obj['ETag'].replace('"', ''),key_data['ETag'].replace('"', ''))
+        eq(obj['ETag'],key_data['ETag'])
         eq(obj['Size'],key_data['ContentLength'])
         eq(obj['Owner']['ID'],key_data['ID'])
         eq(obj['VersionId'], key_data['VersionId'])


### PR DESCRIPTION
As per RFC7232#2.3, the ETag should always contain quotes around.
At the moment, the `test_bucket_list_return_data` fails if listing result actually contains the quotes.
The other test passes in such case, though it should not.

Before you merge this, please give me heads up on slack (omicka), otherwise it can break some of our internal tests.